### PR TITLE
Changing the background color of text selection in code blocks

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -336,8 +336,8 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* General editor styles */
 
-  --jp-editor-selected-background: var(--jp-layout-color2);
-  --jp-editor-selected-focused-background: #d7d4f0;
+  --jp-editor-selected-background: var(--seoul256-dark-selection);
+  --jp-editor-selected-focused-background: var(--seoul256-dark-selection);
   --jp-editor-cursor-color: rgba(216, 216, 216, 1);
 
   /* Code mirror specific styles */


### PR DESCRIPTION
The background color for the code blocks made the normal text not readable as seen here:
![img-2024-07-22-123657](https://github.com/user-attachments/assets/f99b2b20-2314-4717-9527-377db466598a)

so I changed it to the --seoul256-dark-selection variable and it makes the text readable again:
![img-2024-07-22-123106](https://github.com/user-attachments/assets/0f80c928-5e31-4bd5-8b05-5b2aa758a21a)
